### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Cheques Management [![Build Status](https://api.travis-ci.com/apache/fineract-cn-cheques.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-cheques) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-cheques)](https://hub.docker.com/r/apache/fineract-cn-cheques/builds)
+# Apache Fineract CN Cheques Management [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-cheques)](https://hub.docker.com/r/apache/fineract-cn-cheques/builds)
 
 This project provides services to issue, validate cheques and execute transactions on them.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-cheques).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.